### PR TITLE
do not rely on fonts working to show the body

### DIFF
--- a/_less/base/layout.less
+++ b/_less/base/layout.less
@@ -9,7 +9,6 @@ html {
 
 body {
   background: @mono;
-  visibility: hidden;
 }
 
 .content {

--- a/js/fonts.js
+++ b/js/fonts.js
@@ -11,6 +11,10 @@
       id: 'bie6xni'
     },
 
+    loading: function(){
+      $(global).trigger('fonts:loading');
+    },
+
     active: function() {
       $(global).trigger('fonts:active');
     },

--- a/js/main.js
+++ b/js/main.js
@@ -88,6 +88,10 @@
     $('body').css('visibility', 'visible');
   });
 
+  $(global).on('fonts:loading', function() {
+    $('body').css('visibility', 'hidden');
+  });
+
   $('#mc_embed_signup form').on('submit', mailchimpSubmit);
 
   $(hc.smoothScroller);


### PR DESCRIPTION
If users have a plugin like Ghostery installed (or don't have javascript enabled) the body always stays hidden because the font:active event never fires.

This fix fires relies on web fonts functioning properly to hide the body initially and then show it when they are loaded.

To further minimise FOUC you can move fonts.js to the head of the page.
